### PR TITLE
修改 助理排班 页面布局

### DIFF
--- a/Public/css/SchedulingForm.css
+++ b/Public/css/SchedulingForm.css
@@ -15,7 +15,6 @@ body {
 
 ul { list-style-type: none;}
 li { display: inline-span;}
-li { margin: 10px 0;}
 input.labelauty + label { font: 12px "Microsoft Yahei";}
 
 


### PR DESCRIPTION
修改 助理排班 页面的标题和导航栏布局，使之与其他页面的标题和导航栏布局一致。
